### PR TITLE
Updates for plotly 6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: "actions/checkout@v4"
         with:

--- a/src/mutation_motif/draw.py
+++ b/src/mutation_motif/draw.py
@@ -416,14 +416,14 @@ def get_summary_drawable(data, plot_cfg, ylim=None):
     layout.yaxis = UnionDict(
         range=[0, ylim],
         tickfont={"size": plot_cfg.ytick_fontsize},
-        titlefont={"size": plot_cfg.ylabel_fontsize},
+        title={"font": {"size": plot_cfg.ylabel_fontsize}},
     )
     layout.xaxis = UnionDict(
         tickmode="array",
         ticktext=[str(o) for o in order],
         tickvals=order,
         tickfont={"size": plot_cfg.xtick_fontsize},
-        titlefont={"size": plot_cfg.xlabel_fontsize},
+        title={"font": {"size": plot_cfg.xlabel_fontsize}},
     )
 
     axis_lines = {


### PR DESCRIPTION
## Summary by Sourcery

Update Plotly to version 6.0 and add support for Python 3.13.

New Features:
- Add support for Python 3.13.

Enhancements:
- Update Plotly API usage to be compatible with version 6.0.