### PR TITLE
MAINT: update to latest cogent3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 license = { file = "license.txt" }
 requires-python = ">=3.10,<3.14"
 dependencies = ["click",
-        "cogent3",
+        "cogent3>=2025.7.10a3",
         "kaleido",
         "numpy",
         "scipy",

--- a/src/mutation_motif/__init__.py
+++ b/src/mutation_motif/__init__.py
@@ -1,4 +1,4 @@
-"""mutation_motif, software for naalyses of point mutations, see https://www.ncbi.nlm.nih.gov/pubmed/27974498"""
+"""mutation_motif, software for analyses of point mutations, see https://www.ncbi.nlm.nih.gov/pubmed/27974498"""
 
 from warnings import filterwarnings
 
@@ -6,4 +6,4 @@ filterwarnings("ignore", "Attempting to set identical bottom==top")
 filterwarnings("ignore", "invalid value encountered.*")
 
 __license__ = "BSD-3"
-__version__ = "2025.01.28"
+__version__ = "2025.7.17"

--- a/src/mutation_motif/aln_to_counts.py
+++ b/src/mutation_motif/aln_to_counts.py
@@ -3,8 +3,10 @@
 import os
 import re
 
+import cogent3
+
 from mutation_motif import motif_count, profile
-from mutation_motif.util import just_nucs, load_from_fasta, makedirs
+from mutation_motif.util import just_nucs, makedirs
 
 fn_suffixes = re.compile(r"\.(fa|fasta)\.*(gz|gzip|bz2)*$")
 
@@ -44,7 +46,7 @@ def align_to_counts(
 
     direction = tuple(direction.split("to"))
     chosen_base = direction[0]
-    orig_seqs = load_from_fasta(os.path.abspath(align_path))
+    orig_seqs = cogent3.load_aligned_seqs(os.path.abspath(align_path), moltype="dna")
     seqs = orig_seqs.array_seqs
     seqs = just_nucs(seqs)
     if not randomise:

--- a/src/mutation_motif/complement.py
+++ b/src/mutation_motif/complement.py
@@ -17,7 +17,7 @@ def _reverse_complement(table):
     rows = table.to_list()
     for row in rows:
         # we use the cogent3 DnaSeq object to do reverse complementing
-        seq = DNA.make_seq("".join(row[i] for i in pos_indices))
+        seq = DNA.make_seq(seq="".join(row[i] for i in pos_indices))
         seq = list(seq.rc())
         for i, index in enumerate(pos_indices):
             row[index] = seq[i]

--- a/src/mutation_motif/log_lin.py
+++ b/src/mutation_motif/log_lin.py
@@ -5,7 +5,7 @@ import numpy
 import pandas
 import statsmodels.api as sm
 import statsmodels.formula.api as smf
-from cogent3.util.table import Table
+from cogent3.core.table import Table
 from scipy.stats import chi2
 
 _poisson = sm.families.Poisson()

--- a/src/mutation_motif/motif_count.py
+++ b/src/mutation_motif/motif_count.py
@@ -1,9 +1,11 @@
 from collections import Counter
 from itertools import product
 
-from cogent3 import make_table
+from cogent3 import get_moltype, make_table
 
 from mutation_motif.util import array_to_str
+
+dna_alpha = get_moltype("DNA").most_degen_alphabet()
 
 
 def profile_to_seq_counts(data, flank_size):

--- a/src/mutation_motif/util.py
+++ b/src/mutation_motif/util.py
@@ -11,8 +11,6 @@ from importlib import resources
 
 import numpy
 from cogent3 import DNA, load_table, make_table, open_
-from cogent3.core.alignment import ArrayAlignment
-from cogent3.parse.fasta import iter_fasta_records
 from cogent3.util.union_dict import UnionDict
 from pandas import read_json
 
@@ -151,13 +149,9 @@ def is_valid(data):
     return (data >= 0).all() and (data < 4).all()
 
 
-def load_from_fasta(filename):
-    seqs = list(iter_fasta_records(filename))
-    return ArrayAlignment(data=seqs, moltype=DNA)
-
-
 def array_to_str(data):
     """convert numpy array back to DNA sequence"""
+    data = data.astype(numpy.uint8)
     return ["".join(DNA.alphabet.from_indices(v)) for v in data]
 
 

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -178,7 +178,7 @@ class TestRandomIndices(TestCase):
 class TestAlignSnpAnnotation(TestCase):
     seqs = [("seq_0", "ATCAACATATAAAAAGGAAAT")]
 
-    d_aln = make_aligned_seqs(data=seqs, array_align=True, moltype=DNA).array_seqs
+    d_aln = make_aligned_seqs(seqs, moltype=DNA).array_seqs
     step = 3
     slice_side = 7
     direction = "AtoC"

--- a/tests/test_entropy.py
+++ b/tests/test_entropy.py
@@ -16,42 +16,39 @@ from mutation_motif.entropy import (
 def ref_aln(DATA_DIR):
     return load_aligned_seqs(
         DATA_DIR / "entropy/ref.fasta",
-        array_align=True,
         moltype=DNA,
     )
 
 
 @pytest.fixture(scope="session")
 def ref_data(ref_aln):
-    return ref_aln.seq_data
+    return ref_aln.array_seqs
 
 
 @pytest.fixture(scope="session")
 def ctl_aln(DATA_DIR):
     return load_aligned_seqs(
         DATA_DIR / "entropy/control.fasta",
-        array_align=True,
         moltype=DNA,
     )
 
 
 @pytest.fixture(scope="session")
 def ctl_data(ctl_aln):
-    return ctl_aln.seq_data
+    return ctl_aln.array_seqs
 
 
 @pytest.fixture(scope="session")
 def gap_aln(DATA_DIR):
     return load_aligned_seqs(
         DATA_DIR / "entropy/gap.fasta",
-        array_align=True,
         moltype=DNA,
     )
 
 
 @pytest.fixture(scope="session")
 def gap_data(gap_aln):
-    return gap_aln.seq_data
+    return gap_aln.array_seqs
 
 
 def test_validity(ref_data, gap_data):

--- a/tests/test_motif_count.py
+++ b/tests/test_motif_count.py
@@ -1,7 +1,6 @@
 from unittest import TestCase, main
 
-from cogent3 import DNA
-from cogent3.core.alignment import ArrayAlignment
+from cogent3 import DNA, make_aligned_seqs
 
 from mutation_motif.motif_count import (
     get_combined_counts,
@@ -36,7 +35,7 @@ ctl = [(f"s{i}", s) for i, s in enumerate(ctl) if s]
 
 def _get_seq_array(data):
     """returns [(n, seq), ...] as DenseArray"""
-    return ArrayAlignment(data=data, moltype=DNA).array_seqs
+    return make_aligned_seqs(data, moltype=DNA).array_seqs
 
 
 class TestMotifCount(TestCase):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -18,7 +18,6 @@ from mutation_motif.util import (
 def aln(DATA_DIR):
     return load_aligned_seqs(
         DATA_DIR / "just_nuc.fasta",
-        array_align=True,
         moltype=DNA,
     )
 
@@ -49,7 +48,6 @@ def test_just_nucs(aln):
 def d_aln(DATA_DIR):
     return load_aligned_seqs(
         DATA_DIR / "load_seqs_to_array.fasta",
-        array_align=True,
         moltype=DNA,
     )
 


### PR DESCRIPTION
[CHANGED] and bump version to 2025.7.17

## Summary by Sourcery

Migrate the codebase to the latest cogent3 API, update imports and function calls accordingly, adjust tests for removed parameters, and bump the package version and dependency requirement.

Bug Fixes:
- Fix DNA.make_seq call signature in complement.py
- Ensure correct dtype casting in array_to_str

Enhancements:
- Replace custom FASTA loader with cogent3.load_aligned_seqs and update various imports to match the new cogent3 structure
- Refactor motif_count, complement, util, and log_lin modules to use updated cogent3 functions and tables

Build:
- Bump package version to 2025.7.17
- Update cogent3 dependency to >=2025.7.10a3 in pyproject.toml

Tests:
- Remove deprecated array_align parameter in tests and switch to using the .array_seqs attribute
- Update make_aligned_seqs usage in tests to match new API signature

Chores:
- Remove deprecated load_from_fasta utility function