### PR TITLE
Maint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: "actions/checkout@v6"
         with:

--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.11", "3.14"]
 
     steps:
       - uses: "actions/checkout@v6"

--- a/.hgignore
+++ b/.hgignore
@@ -30,3 +30,4 @@ draw_results
 working/*
 .ruff_cache/*
 .venv/*
+.mypy_cache/*

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/ffc29377d3684100b74a868e4a15970d)](https://app.codacy.com/gh/HuttleyLab/MutationMotif/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
-![logo](https://figshare.com/ndownloader/files/23575181)
+![logo](https://github.com/user-attachments/assets/4c9cebc1-847f-40b9-bdad-1becd1781a61)
 
 # Mutation Motif
 
@@ -17,11 +17,11 @@ The description of the models and applications of them are described in [Zhu, Ne
 
 ## Installation
 
-You can just do a pip install 
-
 ```
 $ pip install mutation_motif
 ```
+
+> **Note:** In order to write Plotly figures to static image files you will need to [install Chrome](https://plotly.com/python/static-image-export/#install-dependencies).
 
 ## The commands
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,6 @@
 import nox
 
-_py_versions = range(10, 14)
+_py_versions = range(11, 15)
 
 
 @nox.session(python=[f"3.{v}" for v in _py_versions])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,37 +4,44 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "mutation_motif"
-authors = [
-    { name = "Gavin Huttley", email = "Gavin.Huttley@anu.edu.au"},
+authors = [{ name = "Gavin Huttley", email = "Gavin.Huttley@anu.edu.au" }]
+keywords = [
+    "biology",
+    "genomics",
+    "statistics",
+    "genetics",
+    "evolution",
+    "bioinformatics",
+    "mutation",
 ]
-keywords = ["biology", "genomics", "statistics", "genetics", "evolution", "bioinformatics", "mutation"]
 readme = "README.md"
 license = { file = "license.txt" }
-requires-python = ">=3.10,<3.14"
-dependencies = ["click",
-        "cogent3>=2025.7.10a3",
-        "kaleido",
-        "numpy",
-        "scipy",
-        "scitrack",
-        "pandas",
-        "plotly",
-        "scipy",
-        "statsmodels",
-        ]
+requires-python = ">=3.11,<=3.14"
+dependencies = [
+    "click",
+    "cogent3>=2025.7.10a3",
+    "kaleido",
+    "numpy",
+    "scipy",
+    "scitrack",
+    "pandas",
+    "plotly",
+    "scipy",
+    "statsmodels",
+]
 classifiers = [
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: BSD License",
-        "Topic :: Scientific/Engineering :: Bio-Informatics",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Operating System :: MacOS",
-        "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-    ]
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+]
 dynamic = ["version", "description"]
 
 [project.urls]
@@ -50,27 +57,13 @@ exclude = ["doc/*.html"]
 mm = "mutation_motif.cli:main"
 
 [project.optional-dependencies]
-test = [
-    "pytest",
-    "pytest-cov",
-    "nox",
-]
-dev = [
-    "click",
-    "cog",
-    "flit",
-    "pytest",
-    "pytest-cov",
-    "nox",
-    "ruff",
-]
+test = ["pytest", "pytest-cov", "nox"]
+dev = ["click", "cog", "flit", "pytest", "pytest-cov", "nox", "ruff"]
 
 [tool.pytest.ini_options]
 addopts = ["--strict-config", "-ra"]
 testpaths = "tests"
-markers = [
-    "draws: tests that draw images (deselect with '-m \"not drwas\"')",
-    ]
+markers = ["draws: tests that draw images (deselect with '-m \"not draws\"')"]
 
 [tool.uv]
 reinstall-package = ["mutation_motif"]
@@ -127,18 +120,18 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [
-    "S101", # asserts allowed in tests...
+    "S101",   # asserts allowed in tests...
     "INP001", # __init__.py files are not required...
     "ANN",
     "N802",
-    "N803"
+    "N803",
 ]
 "noxfile.py" = [
-    "S101", # asserts allowed in tests...
+    "S101",   # asserts allowed in tests...
     "INP001", # __init__.py files are not required...
     "ANN",
     "N802",
-    "N803"
+    "N803",
 ]
 
 [tool.ruff.format]


### PR DESCRIPTION
## Summary by Sourcery

Update project metadata, supported Python versions, CI matrices, and documentation assets.

Bug Fixes:
- Correct a typo in the pytest marker description for image-drawing tests.

Enhancements:
- Raise the minimum supported Python version to 3.11 and add support up to Python 3.14 in both project metadata and classifiers.
- Reformat pyproject configuration for consistency and clarity, including optional dependencies and ruff per-file ignores.
- Update the README logo image URL and document the Chrome dependency for Plotly static image export.

CI:
- Adjust CI test and release matrices to run against Python 3.11–3.14.

Documentation:
- Refresh README with a new logo asset and note about Chrome requirements for Plotly image export.