### PR TITLE
DEV: update dependabot to a 7-day cooldown on dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,13 @@ updates:
       interval: weekly
       time: "19:00"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       time: "19:00"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary by Sourcery

Configure Dependabot to enforce a 7-day cooldown between dependency update pull requests.

Build:
- Set a 7-day default cooldown for application dependency updates in Dependabot configuration.
- Set a 7-day default cooldown for GitHub Actions dependency updates in Dependabot configuration.