### PR TITLE
DEV: handle homebrew trust changes

### DIFF
--- a/.github/workflows/testing_develop.yml
+++ b/.github/workflows/testing_develop.yml
@@ -35,6 +35,10 @@ jobs:
 
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@v2
+        env:
+          # macOS installs the coverage-reporter via a third-party Homebrew
+          # tap; Homebrew's new tap-trust enforcement refuses it otherwise.
+          HOMEBREW_NO_REQUIRE_TAP_TRUST: 1
         with:
           parallel: true
           github-token: ${{ secrets.github_token }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the testing_develop GitHub Actions workflow to set HOMEBREW_NO_REQUIRE_TAP_TRUST for the Coveralls job on macOS.